### PR TITLE
Making Control-Your-Tabs Py3 compliant

### DIFF
--- a/controlyourtabs.py
+++ b/controlyourtabs.py
@@ -166,7 +166,7 @@ class ControlYourTabsPlugin(GObject.Object, Gedit.WindowActivatable):
 			self.connect_handlers(self.window, ('tabs-reordered', 'active-tab-changed', 'key-press-event', 'key-release-event', 'focus-out-event'), 'window', notebooks)
 
 		else:
-			print 'ControlYourTabsPlugin: cannot find multi notebook from', cur
+			print ('ControlYourTabsPlugin: cannot find multi notebook from', cur)
 
 	def multi_notebook_notebook_added(self, multi, notebook, notebooks):
 		if notebook not in notebooks:


### PR DESCRIPTION
Making Control-Your-Tabs Py3 compliant (to allow it to work with Gedit 3.8)

Making the print statement Py3 kosher
