### PR TITLE
Fix AttributeError w/ gedit 3.18.3

### DIFF
--- a/controlyourtabs.py
+++ b/controlyourtabs.py
@@ -21,6 +21,11 @@
 
 from gi.repository import GObject, Gtk, Gdk, GdkPixbuf, Gio, Gedit
 from xml.sax.saxutils import escape
+global INTERP_BILINEAR
+try:
+	INTERP_BILINEAR = Gdk.INTERP_BILINEAR
+except AttributeError:
+	INTERP_BILINEAR = GdkPixbuf.InterpType.BILINEAR
 
 class ControlYourTabsPlugin(GObject.Object, Gedit.WindowActivatable):
 	__gtype_name__ = 'ControlYourTabsPlugin'
@@ -415,7 +420,7 @@ class ControlYourTabsPlugin(GObject.Object, Gedit.WindowActivatable):
 				width = width * size / height
 				height = size
 
-			pixbuf = pixbuf.scale_simple(width, height, Gdk.INTERP_BILINEAR)
+			pixbuf = pixbuf.scale_simple(width, height, INTERP_BILINEAR)
 
 		return pixbuf
 


### PR DESCRIPTION
Observed on Xubuntu 16.04

AttributeError: 'gi.repository.Gdk' object has no attribute 'INTERP_BILINEAR'
Traceback (most recent call last):
  File /home/emccann/.local/share/gedit/plugins/controlyourtabs.py, line 243, in on_sync_icon_and_name
    model[path][0] = self._get_tab_icon(tab)
  File /home/emccann/.local/share/gedit/plugins/controlyourtabs.py, line 364, in _get_tab_icon
    pixbuf = self._get_icon(theme, tab.get_document().get_location(), icon_size_height)
  File /home/emccann/.local/share/gedit/plugins/controlyourtabs.py, line 402, in _get_icon
    return self._resize_icon(pixbuf, size)
  File /home/emccann/.local/share/gedit/plugins/controlyourtabs.py, line 418, in _resize_icon
    pixbuf = pixbuf.scale_simple(width, height, Gdk.INTERP_BILINEAR)
  File /usr/lib/python3/dist-packages/gi/overrides/__init__.py, line 39, in **getattr**
    return getattr(self._introspection_module, name)
  File /usr/lib/python3/dist-packages/gi/module.py, line 139, in __getattr__
    self.**name**, name))

Signed-off-by: nuclearmistake nuclearmistake@gmail.com
