### PR TITLE
Add metainfo manifest file

### DIFF
--- a/controlyourtabs/gedit-control-your-tabs.metainfo.xml
+++ b/controlyourtabs/gedit-control-your-tabs.metainfo.xml
@@ -3,7 +3,7 @@
 <component type="addon">
   <id>com.thingsthemselves.gedit.plugins.controlyourtabs</id>
   <extends>org.gnome.gedit.desktop</extends>
-  <name>gedit-control-your-tabs</name>
+  <name>Control Your Tabs</name>
   <summary>Gedit plugin to switch between document tabs using</summary>
   <url type="homepage">https://github.com/jefferyto/gedit-control-your-tabs</url>
   <metadata_license>CC0-1.0</metadata_license>

--- a/controlyourtabs/gedit-control-your-tabs.metainfo.xml
+++ b/controlyourtabs/gedit-control-your-tabs.metainfo.xml
@@ -4,7 +4,7 @@
   <id>com.thingsthemselves.gedit.plugins.controlyourtabs</id>
   <extends>org.gnome.gedit.desktop</extends>
   <name>Control Your Tabs</name>
-  <summary>Gedit plugin to switch between document tabs using</summary>
+  <summary>A gedit plugin to switch between document tabs using Ctrl+Tab</summary>
   <url type="homepage">https://github.com/jefferyto/gedit-control-your-tabs</url>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>

--- a/controlyourtabs/gedit-control-your-tabs.metainfo.xml
+++ b/controlyourtabs/gedit-control-your-tabs.metainfo.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2019 Artem Polishchuk <ego.cordatus@gmail.com> -->
+<component type="addon">
+  <id>gedit-control-your-tabs</id>
+  <extends>org.gnome.gedit.desktop</extends>
+  <name>gedit-control-your-tabs</name>
+  <summary>Gedit plugin to switch between document tabs using</summary>
+  <url type="homepage">https://github.com/jefferyto/gedit-control-your-tabs</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <updatecontact>ego.cordatus@gmail.com</updatecontact>
+</component>

--- a/controlyourtabs/gedit-control-your-tabs.metainfo.xml
+++ b/controlyourtabs/gedit-control-your-tabs.metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2019 Artem Polishchuk <ego.cordatus@gmail.com> -->
 <component type="addon">
-  <id>gedit-control-your-tabs</id>
+  <id>com.thingsthemselves.gedit.plugins.controlyourtabs</id>
   <extends>org.gnome.gedit.desktop</extends>
   <name>gedit-control-your-tabs</name>
   <summary>Gedit plugin to switch between document tabs using</summary>


### PR DESCRIPTION
I realized that we can add [metainfo file](https://docs.fedoraproject.org/en-US/packaging-guidelines/AppData/#_metainfo_xml_file_creation) and other users can easily discover and install **gedit-control-your-tabs** via GNOME Software for example.
